### PR TITLE
fix typo that disabling play_macro by accident

### DIFF
--- a/lua/NeoComposer/maps.lua
+++ b/lua/NeoComposer/maps.lua
@@ -27,7 +27,7 @@ function maps.setup()
   if config.keymaps.toggle_record then
     map("n", config.keymaps.toggle_record, "<cmd>lua require('NeoComposer.macro').toggle_record()<cr>", opts)
   end
-  if config.keymaps.toggle_play_macro then
+  if config.keymaps.play_macro then
     map({ "n", "x" }, config.keymaps.play_macro, "<cmd>lua require('NeoComposer.macro').toggle_play_macro()<cr>", opts)
   end
 end


### PR DESCRIPTION
introduced by d9be94452c19797369c934b9eb2968cd1e47a761